### PR TITLE
Correct CMake version check; VERSION_GREATER 3.18 is true for 3.18.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,17 +24,17 @@ target_link_libraries(boost_bloom
 
 target_compile_features(boost_bloom INTERFACE cxx_std_11)
 
-if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
+if(NOT CMAKE_VERSION VERSION_LESS 3.19 AND CMAKE_GENERATOR MATCHES "Visual Studio")
 
-  add_subdirectory(test)
-
-endif()
-
-if(CMAKE_VERSION VERSION_GREATER 3.18 AND CMAKE_GENERATOR MATCHES "Visual Studio")
-
-  file(GLOB_RECURSE boost_bloom_IDEFILES CONFIGURE_DEPENDS "include/**/*.hpp")
+  file(GLOB_RECURSE boost_bloom_IDEFILES CONFIGURE_DEPENDS "include/*.hpp")
   source_group(TREE ${PROJECT_SOURCE_DIR}/include FILES ${boost_bloom_IDEFILES} PREFIX "Header Files")
   list(APPEND boost_bloom_IDEFILES extra/boost_bloom.natvis)
   target_sources(boost_bloom PRIVATE ${boost_bloom_IDEFILES})
+
+endif()
+
+if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
+
+  add_subdirectory(test)
 
 endif()


### PR DESCRIPTION
Also move block before `add_subdirectory(test)` and remove extraneous `**` implied by `GLOB_RECURSE`.